### PR TITLE
Update workflow to install from pyproject

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
+        if [ -f pyproject.toml ]; then pip install .; fi
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |


### PR DESCRIPTION
## Summary
- allow workflow to install dependencies with `pip install .` when `pyproject.toml` exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb818e54c832b8e294905c011c79e