### PR TITLE
Add httpimport test

### DIFF
--- a/.github/workflows/python-package-windows.yml
+++ b/.github/workflows/python-package-windows.yml
@@ -1,7 +1,6 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# This workflow runs tests on Windows using Python 3.10
 
-name: Python package
+name: Python package (Windows)
 
 on:
   push:
@@ -11,8 +10,7 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
@@ -32,9 +30,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ python = ">=3.8"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"
+httpimport = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_httpimport.py
+++ b/tests/test_httpimport.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import importlib
+import httpimport
+
+GITHUB_USER = "TakashiSasaki"
+GITHUB_REPO = "logstore"
+GITHUB_REF = "refs/heads/main/src"
+
+def test_httpimport_remote():
+    local_src = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+    if local_src in sys.path:
+        sys.path.remove(local_src)
+        removed = True
+    else:
+        removed = False
+    try:
+        with httpimport.github_repo(GITHUB_USER, GITHUB_REPO, ref=GITHUB_REF):
+            mod = importlib.import_module('logstore')
+            assert hasattr(mod, 'SQLiteHandler')
+    finally:
+        if removed:
+            sys.path.insert(0, local_src)
+


### PR DESCRIPTION
## Summary
- add test for remote import using github_repo
- add `httpimport` to dev dependencies
- install dev deps in CI workflows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for httpimport)*


------
https://chatgpt.com/codex/tasks/task_e_685cba7d64f0832bbacc63151e949f76