### PR TITLE
Add httpimport instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,19 @@ SQLite database.  It captures a rich set of attributes from each
 ``LogRecord`` so that log entries include not only the formatted message but
 also contextual information such as the logger name, file, line number and
 process/thread identifiers.
+
+## Importing with `httpimport`
+
+You can use [`httpimport`](https://pypi.org/project/httpimport/) to load
+``logstore`` directly from GitHub without installing it.  This can be useful
+in notebooks or throwaway scripts:
+
+```python
+import httpimport
+
+with httpimport.github_repo('TakashiSasaki', 'logstore', ref='refs/heads/main/src'):
+    from logstore import SQLiteHandler
+
+```
+
+After the ``with`` block exits the module is removed from ``sys.modules``.


### PR DESCRIPTION
## Summary
- show how to load `logstore` via httpimport in README

## Testing
- `pytest -q` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685cbedb0ad4832b88d8a039f5f8bc0e